### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1763,10 +1763,10 @@ Please ensure you include the **Source** (link to the original creator) to give 
 
 ## 13. Star History
 
-<a href="https://star-history.com/#ZeroLu/awesome-nanbanana-pro&Date">
+<a href="https://star-history.dera.page/#ZeroLu/awesome-nanbanana-pro&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=ZeroLu/awesome-nanobanana-pro&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart at the bottom of the README is currently broken and no longer displays. This change updates the chart to a working alternative so visitors can still see the repository's star history.

No badges are affected; only the star history chart is updated.